### PR TITLE
add netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+# fix preview faliure
+
+[build]
+  base = "content/2023/"
+  command = "env SITEURL=$DEPLOY_PRIME_URL make html"
+  publish = "output"
+
+[context.production]
+  command = "env SITEURL=$URL make html"


### PR DESCRIPTION
This PR adds `netlify.toml` to configure build, which overrides netlify UI build setting. 